### PR TITLE
Added ascii

### DIFF
--- a/charset.go
+++ b/charset.go
@@ -37,7 +37,7 @@ var CharsetReader func(charset string, input io.Reader) (io.Reader, error)
 // charsetReader calls CharsetReader if non-nil.
 func charsetReader(charset string, input io.Reader) (io.Reader, error) {
 	charset = strings.ToLower(charset)
-	if charset == "utf-8" || charset == "us-ascii" {
+	if charset == "utf-8" || charset == "us-ascii" || charset == "ascii"{
 		return input, nil
 	}
 	if CharsetReader != nil {


### PR DESCRIPTION
Some email parts has "ascii" but not "us-ascii" as charset. So i added it to the "or" statement to allow this charset instead of throwing an error.